### PR TITLE
Remove max width from .intro and edit button copy / style

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "@cycle/xstream-run": "^3.0.3",
     "cycle-restart": "0.0.14",
     "cyclic-router": "^2.1.2",
+    "history": "^3.0.0",
+    "webpack-dev-server": "^1.14.1",
     "xstream": "^5.0.6"
   }
 }

--- a/src/Components/Intro/index.js
+++ b/src/Components/Intro/index.js
@@ -25,7 +25,7 @@ export default function Intro(sources){
             input('.btn.anim',{props: {
               type: 'submit',
               name: 'submit',
-              value: 'order now'
+              value: 'shut up and take my money'
             }}),
           // a('.btn.anim', { props: {href: '/buy-now'} },'order now')
         ])

--- a/src/Components/Intro/style.scss
+++ b/src/Components/Intro/style.scss
@@ -9,7 +9,6 @@ $order-button-font: 700 4.4em /1 'Open Sans', sans-serif;
 
 .intro {
   height: 100vh;
-  max-width: 1334px;
   background: url('../../Static/intro_image.png') no-repeat center black;
   background-size: contain;
   align-items: center;
@@ -22,9 +21,9 @@ a {
 input.btn {
   border-radius: 5px;
   box-shadow: 1px 1px 20px 3px hsla(0, 0%, 0%, .6);
-  width: 7em;
-  max-height: 1em;
-  padding: 0;
+  max-height: 1.1em;
+  padding: 0.1em;
+  margin-bottom: 0.8em;
   text-transform: uppercase;
   text-shadow: 0 1px 0 hsla(0, 0%, 0%, .25);
   font: $order-button-font;


### PR DESCRIPTION
So max width was totally harshing the vibe on the intro brah:

[width mismatch](https://drive.google.com/open?id=0B-gRZdZ8Cf_mam5tdkNmbl9ST1U)

I like the full screen no bleed type look for this, but another option that looks tight would to make the whole page partial width and centered. We could put this up in the #root div:

```
margin: 0 auto;
max-width: 1334px;
background-color: black;
```

I like the full height intro section, but didn't dig the button sitting right on the bottom of my screen:

[button with the ass dropped](https://drive.google.com/open?id=0B-gRZdZ8Cf_mak5mck1OMmo4LVk)

I ain't for that, so added some margin to the bottom. 

I like the idea of a less generic CTA and made a suggestion. That required some style changes and I thought the text could use some padding so it's not crashing against the button border. The action CTA might need some more brainstorming, but you get the idea.

Also, bonus points if we could somehow get the image to lead one's eyes to the CTA button, but I don't have any bright ideas. 
